### PR TITLE
実装 - 読んだ章をデータとして保持する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@react-native-async-storage/async-storage": "~1.15.0",
         "@react-native-community/masked-view": "0.1.10",
         "@react-navigation/bottom-tabs": "^5.11.11",
         "@react-navigation/native": "^5.9.4",
@@ -2605,6 +2606,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.7.tgz",
+      "integrity": "sha512-ctD51BxjBxSSZ/3xCxQ//e10nP3rWFuOABsOGCGCqCXO4ypznK+fcWONHI6fIZubfV5KdyBJnNXcKtXRjocE5Q==",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || ^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || ^0.65.0 || 1000.0.0"
+      }
     },
     "node_modules/@react-native-community/cli-debugger-ui": {
       "version": "4.13.1",
@@ -7551,6 +7563,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -8685,6 +8705,17 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge-stream": {
@@ -15428,6 +15459,14 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@react-native-async-storage/async-storage": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.7.tgz",
+      "integrity": "sha512-ctD51BxjBxSSZ/3xCxQ//e10nP3rWFuOABsOGCGCqCXO4ypznK+fcWONHI6fIZubfV5KdyBJnNXcKtXRjocE5Q==",
+      "requires": {
+        "merge-options": "^3.0.4"
+      }
+    },
     "@react-native-community/cli-debugger-ui": {
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz",
@@ -19310,6 +19349,11 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -20239,6 +20283,14 @@
       "integrity": "sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==",
       "requires": {
         "buffer-alloc": "^1.1.0"
+      }
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
       }
     },
     "merge-stream": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.4.0",
-    "react-native-web": "~0.13.12"
+    "react-native-web": "~0.13.12",
+    "@react-native-async-storage/async-storage": "~1.15.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/screens/Chapter.tsx
+++ b/src/screens/Chapter.tsx
@@ -1,12 +1,20 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { StyleSheet, View, FlatList } from 'react-native';
 import { CheckBox } from 'react-native-elements'
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 type Chapters = {
   id: number;
   bookId: number;
   number: number;
 }[]
+
+type Chapter = {
+  id: number;
+  bookId: number;
+  number: number;
+}
 
 const chapters: Chapters = [
   {
@@ -110,25 +118,65 @@ type Route = {
 
 export const ChapterScreen = ({ route }: { route: Route }) => {
   const { bookId } = route.params;
-  const data: Chapters = chapters.filter(chapter => chapter.bookId === bookId);
+  // 選択した書簡の章を抽出する
+  const currentChapters: Chapters = chapters.filter(chapter => chapter.bookId === bookId);
 
+  // 章の通読状態を初期値 false で生成する
   const [checkedState, setCheckedState] = useState(
-    new Array(data.length).fill(false)
+    new Array(currentChapters.length).fill(false)
   );
 
-  const handleOnChange = (position: number) => {
+  useEffect(() => {
+    fetchReadChapters(currentChapters);
+  }, [])
+
+  // ローカルストレージから章の通読状態を state に反映する
+  const fetchReadChapters = async (chapters: Chapters) => {
+    try {
+      const keys = await AsyncStorage.getAllKeys();
+      const updatedCheckedState = chapters.map(chapter => keys.includes('readChapters:id:' + chapter.id));
+
+      setCheckedState(updatedCheckedState);
+    } catch(e) {
+      console.log(e);
+    }
+  };
+
+  const handleOnChange = (chapter: Chapter, position: number) => {
     const updatedCheckedState = checkedState.map((item, index) =>
       index === position ? !item : item
     );
 
+    if (updatedCheckedState[position]) {
+      storeReadChapter(chapter);
+    } else {
+      removeReadChapter(chapter);
+    }
+
     setCheckedState(updatedCheckedState);
+  };
+
+  const storeReadChapter = async (chapter: Chapter) => {
+    try {
+      await AsyncStorage.setItem('readChapters:id:' + chapter.id, String(Date.now()));
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const removeReadChapter = async (chapter: Chapter) => {
+    try {
+      await AsyncStorage.removeItem('readChapters:id:' + chapter.id);
+    } catch (e) {
+      console.log(e);
+    }
   };
 
   return (
     <View style={styles.container}>
       <FlatList
         style={styles.list}
-        data={data}
+        data={currentChapters}
         keyExtractor={item => `${item.id}`}
         renderItem={({ item, index }) => (
           <CheckBox
@@ -136,7 +184,8 @@ export const ChapterScreen = ({ route }: { route: Route }) => {
             textStyle={styles.checkBoxText}
             title={`${item.number}章`}
             checked={checkedState[index]}
-            onPress={() => handleOnChange(index)}
+            onPress={() => {handleOnChange(item, index)}
+            }
           />
         )}
       />


### PR DESCRIPTION
Resolves #21

### 実装方針

* async-storage を使ってローカルストレージに通読した章を保持する。（ユーザログイン不要）
* useEffect で通読した章を画面に反映する

### 確認済み

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-08-27 at 08 48 44](https://user-images.githubusercontent.com/17666221/131050163-dfda6a10-ae68-4f8e-9d94-75c6197104be.png)
